### PR TITLE
feat: auth (register/login) + list upcoming shifts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,135 @@
+import os, sqlite3
+from flask import Flask, g, render_template, request, redirect, url_for, session, flash
+from werkzeug.security import generate_password_hash, check_password_hash
+from datetime import datetime, timedelta
+
+DB_PATH = os.environ.get("DB_PATH", os.path.join(os.path.dirname(__file__), "shifts.db"))
+SECRET = os.environ.get("SECRET_KEY", "dev_secret_change_me")
+
+app = Flask(__name__)
+app.config.update(SECRET_KEY=SECRET)
+
+# ---------- DB helpers ----------
+def get_db():
+    if "db" not in g:
+        g.db = sqlite3.connect(DB_PATH)
+        g.db.row_factory = sqlite3.Row
+    return g.db
+
+@app.teardown_appcontext
+def close_db(exc):
+    db = g.pop("db", None)
+    if db is not None:
+        db.close()
+
+def init_db():
+    db = get_db()
+    # run schema
+    with open(os.path.join(os.path.dirname(__file__), "schema.sql"), "r") as f:
+        db.executescript(f.read())
+    # seed admin + one sample shift if empty
+    count = db.execute("SELECT COUNT(*) AS c FROM app_user").fetchone()["c"]
+    if count == 0:
+        db.execute(
+            "INSERT INTO app_user(email,password_hash,role) VALUES (?,?,?)",
+            ("admin@example.com", generate_password_hash("admin123"), "ADMIN"),
+        )
+    if db.execute("SELECT COUNT(*) AS c FROM shift").fetchone()["c"] == 0:
+        starts = (datetime.now() + timedelta(days=1)).replace(hour=9, minute=0, second=0, microsecond=0)
+        ends = starts + timedelta(hours=3)
+        db.execute(
+            "INSERT INTO shift(title,location,starts_at,ends_at,capacity) VALUES (?,?,?,?,?)",
+            ("Food Bank Morning Shift", "Community Center", starts.isoformat(), ends.isoformat(), 3),
+        )
+    db.commit()
+
+# ---------- auth utils ----------
+def current_user():
+    uid = session.get("uid")
+    if not uid: return None
+    return get_db().execute("SELECT * FROM app_user WHERE id=?", (uid,)).fetchone()
+
+def login_required(fn):
+    from functools import wraps
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not current_user():
+            return redirect(url_for("login"))
+        return fn(*args, **kwargs)
+    return wrapper
+
+# ---------- routes: auth ----------
+@app.route("/register", methods=["GET","POST"])
+def register():
+    if request.method == "POST":
+        email = request.form["email"].strip().lower()
+        pw = request.form["password"]
+        db = get_db()
+        try:
+            db.execute(
+                "INSERT INTO app_user(email,password_hash,role) VALUES (?,?,?)",
+                (email, generate_password_hash(pw), "VOLUNTEER"),
+            )
+            db.commit()
+            flash("Registration successful. Please log in.")
+            return redirect(url_for("login"))
+        except sqlite3.IntegrityError:
+            flash("Email already registered")
+    return render_template("register.html")
+
+@app.route("/login", methods=["GET","POST"])
+def login():
+    if request.method == "POST":
+        email = request.form["email"].strip().lower()
+        pw = request.form["password"]
+        user = get_db().execute("SELECT * FROM app_user WHERE email=?", (email,)).fetchone()
+        if user and check_password_hash(user["password_hash"], pw):
+            session["uid"] = user["id"]
+            session["role"] = user["role"]
+            return redirect(url_for("index"))
+        flash("Invalid credentials")
+    return render_template("login.html")
+
+@app.get("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("index"))
+
+# ---------- routes: core pages ----------
+@app.get("/")
+def index():
+    # list future shifts with spots left
+    rows = get_db().execute(
+        """
+        SELECT s.*,
+               COALESCE((SELECT COUNT(*) FROM signup x WHERE x.shift_id=s.id),0) AS taken
+        FROM shift s
+        WHERE datetime(s.ends_at) > datetime('now')
+        ORDER BY s.starts_at ASC
+        """
+    ).fetchall()
+    return render_template("index.html", shifts=rows, me=current_user())
+
+@app.get("/my")
+@login_required
+def my_shifts():
+    # will be populated in the next step when we add signups
+    items = get_db().execute(
+        """
+        SELECT s.title, s.starts_at, s.ends_at, su.id AS signup_id
+        FROM signup su JOIN shift s ON s.id=su.shift_id
+        WHERE su.user_id=?
+        ORDER BY su.created_at DESC
+        """,
+        (current_user()["id"],),
+    ).fetchall()
+    return render_template("my.html", items=items)
+
+# ---------- entrypoint ----------
+if __name__ == "__main__":
+    # ensure DB file exists and is initialized
+    if not os.path.exists(DB_PATH):
+        open(DB_PATH, "a").close()
+    with app.app_context():
+        init_db()
+    app.run(debug=True)

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,26 @@
+-- users
+CREATE TABLE IF NOT EXISTS app_user (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('ADMIN','VOLUNTEER'))
+);
+
+-- shifts
+CREATE TABLE IF NOT EXISTS shift (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  location TEXT,
+  starts_at TEXT NOT NULL,   -- ISO datetime string
+  ends_at   TEXT NOT NULL,
+  capacity  INTEGER NOT NULL DEFAULT 1
+);
+
+-- signups (unique per user per shift) -- used in next step
+CREATE TABLE IF NOT EXISTS signup (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  shift_id INTEGER NOT NULL REFERENCES shift(id) ON DELETE CASCADE,
+  user_id  INTEGER NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (shift_id, user_id)
+);

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Shift Scheduler</title>
+  <style>body{font-family:system-ui,Arial;margin:2rem} nav a{margin-right:1rem}</style>
+</head>
+<body>
+<nav>
+  <a href="/">Home</a>
+  <a href="/my">My Shifts</a>
+  <a href="/login">Login</a>
+  <a href="/register">Register</a>
+  <a href="/logout">Logout</a>
+</nav>
+<hr>
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    <ul>{% for m in messages %}<li>{{ m }}</li>{% endfor %}</ul>
+  {% endif %}
+{% endwith %}
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Upcoming Shifts</h2>
+<table border="1" cellpadding="6">
+  <tr><th>Title</th><th>When</th><th>Where</th><th>Spots left</th></tr>
+  {% for s in shifts %}
+  <tr>
+    <td>{{ s['title'] }}</td>
+    <td>{{ s['starts_at'] }} – {{ s['ends_at'] }}</td>
+    <td>{{ s['location'] }}</td>
+    <td>{{ s['capacity'] - s['taken'] }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  <label>Email <input type="email" name="email" required></label><br>
+  <label>Password <input type="password" name="password" required></label><br>
+  <button>Login</button>
+</form>
+{% endblock %}

--- a/templates/my.html
+++ b/templates/my.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>My Shifts</h2>
+{% if not items %}
+<p>No signups yet.</p>
+{% else %}
+<table border="1" cellpadding="6">
+  <tr><th>Shift</th><th>When</th></tr>
+  {% for i in items %}
+  <tr>
+    <td>{{ i['title'] }}</td>
+    <td>{{ i['starts_at'] }} – {{ i['ends_at'] }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endif %}
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Register</h2>
+<form method="post">
+  <label>Email <input type="email" name="email" required></label><br>
+  <label>Password <input type="password" name="password" required></label><br>
+  <button>Create account</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
What I did
- I added the initial database schema.
- I seeded an admin user and one sample shift.
- I built register/login/logout and the home page that lists upcoming shifts.

Why
- This gives me a working base to continue (sign-ups, admin, CI).

How to test
1) Run `python app.py`
2) Open http://127.0.0.1:5000
3) Register a user, then log in.
4) You should see “Food Bank Morning Shift” on the home page.



Notes
- Default admin: `admin@example.com` / `admin123` (I will change later).
