### PR TITLE
feat: sign-up + cancel + admin; add test and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          PYTHONPATH: .
+        run: pytest -q
+

--- a/templates/admin_new_shift.html
+++ b/templates/admin_new_shift.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>New Shift (Admin)</h2>
+<p><em>Login as admin@example.com / admin123 to access this page.</em></p>
+<form method="post" action="/admin/shifts">
+  <label>Title <input name="title" required></label><br>
+  <label>Location <input name="location"></label><br>
+  <label>Starts <input type="datetime-local" name="starts_at" required></label><br>
+  <label>Ends <input type="datetime-local" name="ends_at" required></label><br>
+  <label>Capacity <input type="number" name="capacity" min="1" value="1"></label><br>
+  <button>Create</button>
+</form>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,10 +9,17 @@
 <nav>
   <a href="/">Home</a>
   <a href="/my">My Shifts</a>
-  <a href="/login">Login</a>
-  <a href="/register">Register</a>
-  <a href="/logout">Logout</a>
+  {% if session.role == 'ADMIN' %}
+    <a href="/admin/shifts/new">Admin: New Shift</a>
+  {% endif %}
+  {% if session.uid %}
+    <a href="/logout">Logout</a>
+  {% else %}
+    <a href="/login">Login</a>
+    <a href="/register">Register</a>
+  {% endif %}
 </nav>
+
 <hr>
 {% with messages = get_flashed_messages() %}
   {% if messages %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,13 +2,19 @@
 {% block content %}
 <h2>Upcoming Shifts</h2>
 <table border="1" cellpadding="6">
-  <tr><th>Title</th><th>When</th><th>Where</th><th>Spots left</th></tr>
+  <tr><th>Title</th><th>When</th><th>Where</th><th>Spots left</th><th>Action</th></tr>
   {% for s in shifts %}
+  {% set spots_left = s['capacity'] - s['taken'] %}
   <tr>
     <td>{{ s['title'] }}</td>
     <td>{{ s['starts_at'] }} – {{ s['ends_at'] }}</td>
     <td>{{ s['location'] }}</td>
-    <td>{{ s['capacity'] - s['taken'] }}</td>
+    <td>{{ spots_left }}</td>
+    <td>
+      <form method="post" action="/shifts/{{ s['id'] }}/signups">
+        <button {% if spots_left <= 0 %}disabled{% endif %}>Sign Up</button>
+      </form>
+    </td>
   </tr>
   {% endfor %}
 </table>

--- a/templates/my.html
+++ b/templates/my.html
@@ -5,11 +5,16 @@
 <p>No signups yet.</p>
 {% else %}
 <table border="1" cellpadding="6">
-  <tr><th>Shift</th><th>When</th></tr>
+  <tr><th>Shift</th><th>When</th><th>Action</th></tr>
   {% for i in items %}
   <tr>
     <td>{{ i['title'] }}</td>
     <td>{{ i['starts_at'] }} – {{ i['ends_at'] }}</td>
+    <td>
+      <form method="post" action="/signups/{{ i['signup_id'] }}/cancel">
+        <button>Cancel</button>
+      </form>
+    </td>
   </tr>
   {% endfor %}
 </table>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,18 @@
+import os, sys, tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+fd, path = tempfile.mkstemp()
+os.close(fd)
+os.environ["DB_PATH"] = path
+
+import app as appmod  
+
+def test_index_works():
+    app = appmod.app
+    with app.app_context():
+        appmod.init_db()
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"Upcoming Shifts" in resp.data


### PR DESCRIPTION
What I did
- Added POST /shifts/<id>/signups with capacity guard and unique-per-user.
- Added GET /my and POST /signups/<id>/cancel.
- Added admin form at /admin/shifts/new + POST /admin/shifts.
- Added a tiny pytest and CI workflow (GitHub Actions).

How to test
- Run `python app.py`. Sign up for the sample shift, see it in /my, then cancel.
- As admin@example.com, create a new shift and see it on Home.

Linked issues
Closes #4   Closes #5   Closes #6 
